### PR TITLE
Add WebKit2GTK integration for HTML preview and update handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "gtk3"
-gem "redcarpet" # Markdown parser
-gem "rouge"     # Syntax highlighter
-gem "prawn"     # PDF generation
+gem "webkit2-gtk" # WebKit GTK
+gem "redcarpet"   # Markdown parser
+gem "rouge"       # Syntax highlighter
+gem "prawn"       # PDF generation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
     rouge (4.6.1)
     ttfunk (1.8.0)
       bigdecimal (~> 3.1)
+    webkit2-gtk (4.3.3)
+      gtk3 (= 4.3.3)
+      rake
 
 PLATFORMS
   ruby
@@ -62,6 +65,7 @@ DEPENDENCIES
   prawn
   redcarpet
   rouge
+  webkit2-gtk
 
 BUNDLED WITH
    2.7.2

--- a/lib/preview_pane.rb
+++ b/lib/preview_pane.rb
@@ -1,20 +1,22 @@
 require 'gtk3'
+require 'webkit2-gtk'
 
 class PreviewPane
   attr_reader :widget
 
   def initialize
-    @label = Gtk::Label.new("Preview will appear here")
-    @label.wrap = true
+    # Create WebView for HTML content
+    @webview = WebKit2Gtk::WebView.new
 
+    # Wrap in a scrolled window
     @scrolled_window = Gtk::ScrolledWindow.new
     @scrolled_window.set_policy(:automatic, :automatic)
-    @scrolled_window.add(@label)
+    @scrolled_window.add(@webview)
 
     @widget = @scrolled_window
   end
 
-  def update(content)
-    @label.text = content
+  def update(html_content)
+    @webview.load_html(html_content, "file://")
   end
 end

--- a/main.rb
+++ b/main.rb
@@ -26,7 +26,9 @@ paned.position = 400
 
 # Live update
 editor.on_text_change do |text|
-  preview.update(text)
+  # For now, just pass raw text as HTML
+  html = "<pre>#{text}</pre>"
+  preview.update(html)
 end
 
 window.show_all


### PR DESCRIPTION
This pull request introduces a new HTML-based preview pane, replacing the previous plain text label with a WebKit-powered view for richer content display. The most important changes are grouped below.

Preview pane upgrade:

* Replaced the plain `Gtk::Label` preview with a `WebKit2Gtk::WebView`, enabling rendering of HTML content in the preview pane (`lib/preview_pane.rb`).
* Updated the preview update method to load HTML content into the WebView instead of setting label text (`lib/preview_pane.rb`).
* Changed the live update logic to wrap editor text in HTML before sending it to the preview pane (`main.rb`).

Dependency management:

* Added the `webkit2-gtk` gem to the `Gemfile` to support the new HTML preview functionality (`Gemfile`).