### PR TITLE
Markdown parser

### DIFF
--- a/lib/markdown_parser.rb
+++ b/lib/markdown_parser.rb
@@ -1,8 +1,9 @@
 require 'redcarpet'
+require_relative 'markdown_renderer'
 
 class MarkdownParser
   def initialize
-    @renderer = Redcarpet::Render::HTML.new
+    @renderer = HTMLWithRouge.new
     @markdown = Redcarpet::Markdown.new(@renderer,
       fenced_code_blocks: true,
       tables: true,

--- a/lib/markdown_parser.rb
+++ b/lib/markdown_parser.rb
@@ -1,0 +1,16 @@
+require 'redcarpet'
+
+class MarkdownParser
+  def initialize
+    @renderer = Redcarpet::Render::HTML.new
+    @markdown = Redcarpet::Markdown.new(@renderer,
+      fenced_code_blocks: true,
+      tables: true,
+      autolink: true
+    )
+  end
+
+  def to_html(text)
+    @markdown.render(text)
+  end
+end

--- a/lib/markdown_renderer.rb
+++ b/lib/markdown_renderer.rb
@@ -1,0 +1,7 @@
+require 'rouge'
+require 'redcarpet'
+require 'rouge/plugins/redcarpet'
+
+class HTMLWithRouge < Redcarpet::Render::HTML
+  include Rouge::Plugins::Redcarpet
+end

--- a/lib/preview_pane.rb
+++ b/lib/preview_pane.rb
@@ -5,10 +5,8 @@ class PreviewPane
   attr_reader :widget
 
   def initialize
-    # Create WebView for HTML content
     @webview = WebKit2Gtk::WebView.new
 
-    # Wrap in a scrolled window
     @scrolled_window = Gtk::ScrolledWindow.new
     @scrolled_window.set_policy(:automatic, :automatic)
     @scrolled_window.add(@webview)

--- a/main.rb
+++ b/main.rb
@@ -1,21 +1,25 @@
 require 'gtk3'
+require 'rouge'
 require_relative 'lib/editor_pane'
 require_relative 'lib/preview_pane'
 require_relative 'lib/markdown_parser'
 
+# Create main window
 window = Gtk::Window.new
 window.set_title("Textura")
 window.set_default_size(800, 600)
 window.signal_connect("destroy") { Gtk.main_quit }
 
+# Split pane
 paned = Gtk::Paned.new(:horizontal)
 window.add(paned)
 
+# Editor and preview panes
 editor = EditorPane.new
 preview = PreviewPane.new
 parser = MarkdownParser.new
 
-# Ensure minimum sizes
+# Minimum sizes
 editor.widget.set_size_request(200, 100)
 preview.widget.set_size_request(200, 100)
 
@@ -23,13 +27,35 @@ preview.widget.set_size_request(200, 100)
 paned.add1(editor.widget)
 paned.add2(preview.widget)
 
-# Set initial divider position
+# Set initial divider position (center)
 paned.position = 400
+window.signal_connect("size-allocate") do |widget, allocation|
+  paned.position = allocation.width / 2
+end
 
-# Live update
+# Rouge CSS
+ROUGE_CSS = Rouge::Themes::ThankfulEyes.new.render
+
+# Live Markdown update
 editor.on_text_change do |text|
-  html = parser.to_html(text)
-  preview.update(html)
+  html_body = parser.to_html(text)
+
+  full_html = <<~HTML
+    <html>
+      <head>
+        <style>
+          #{ROUGE_CSS}
+          body { font-family: sans-serif; padding: 10px; }
+          pre { margin: 0; }
+        </style>
+      </head>
+      <body>
+        #{html_body}
+      </body>
+    </html>
+  HTML
+
+  preview.update(full_html)
 end
 
 window.show_all

--- a/main.rb
+++ b/main.rb
@@ -1,6 +1,7 @@
 require 'gtk3'
 require_relative 'lib/editor_pane'
 require_relative 'lib/preview_pane'
+require_relative 'lib/markdown_parser'
 
 window = Gtk::Window.new
 window.set_title("Textura")
@@ -12,6 +13,7 @@ window.add(paned)
 
 editor = EditorPane.new
 preview = PreviewPane.new
+parser = MarkdownParser.new
 
 # Ensure minimum sizes
 editor.widget.set_size_request(200, 100)
@@ -26,8 +28,7 @@ paned.position = 400
 
 # Live update
 editor.on_text_change do |text|
-  # For now, just pass raw text as HTML
-  html = "<pre>#{text}</pre>"
+  html = parser.to_html(text)
   preview.update(html)
 end
 


### PR DESCRIPTION
This pull request introduces Markdown rendering with syntax highlighting to the application's live preview pane. The main changes include the addition of a Markdown parser using Redcarpet and Rouge, integration of syntax-highlighted HTML output into the preview pane, and updates to the main application logic to support these features.

**Markdown rendering and syntax highlighting:**

* Added new `MarkdownParser` class in `lib/markdown_parser.rb` that uses Redcarpet for Markdown parsing and Rouge for syntax highlighting, with a custom renderer defined in `lib/markdown_renderer.rb`. [[1]](diffhunk://#diff-ef0b2ebe8a2f9572fe6a1193eec33d122063bff0ac6d339d6fa79dd69deda005R1-R17) [[2]](diffhunk://#diff-a30a3b663aea38064587365603cd69010625bb221610a53bed1d977baf697ba4R1-R7)

**Preview pane and application integration:**

* Updated `main.rb` to use the new `MarkdownParser` for live preview, generating full HTML output with embedded Rouge CSS for syntax highlighting and improved styling.
* Ensured that the preview pane displays rendered Markdown instead of raw text, including code block highlighting.

**UI improvements:**

* Centered the divider in the split pane dynamically when resizing the main window for a better user experience.
* Cleaned up the `PreviewPane` initialization by removing redundant comments and clarifying widget setup.